### PR TITLE
Add ability to validate cluster config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,17 @@ In order to create or update a cluster, a user must provide a cluster configurat
 - `nodes`: The number of control plane and worker nodes the cluster will have
 - `applications`: A list of the applications to be deployed to the cluster (currently all applications are created as deployments)
 
-Please note that applications have the following fields:
+User applications have the following fields:
 - `name`: The name of the application
 - `namespace`: The namespace in which the application will reside
 - `replicas`: The number of deployment replicas the application will be deployed on
 - `image`: The application's image
+
+Please note that the names for clusters, application names, and application namespaces must adhere to the following convention:
+- name must only contain lowercase letters, numbers, and hyphens
+- name must start with a lowercase letter
+- name must only end with a lowercase letter or number
+
 
 #### Create the cluster
 

--- a/cluster/create.go
+++ b/cluster/create.go
@@ -25,6 +25,13 @@ func (c *Cluster) Create(ctx context.Context) error {
 		return err
 	}
 
+	// validate cluster configuration
+	if err = c.Validate(ctx); err != nil {
+		err = fmt.Errorf("an error occurred while validating cluster configuration: %w", err)
+		slog.Error(err.Error())
+		return err
+	}
+
 	slog.Info("Starting creation of cluster. Please note this may take some time")
 
 	if c.ConfigFile == "" {

--- a/cluster/validate.go
+++ b/cluster/validate.go
@@ -1,0 +1,129 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"unicode"
+
+	"github.com/docker/docker/client"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func (c *Cluster) Validate(ctx context.Context) error {
+	config, err := c.parseConfig()
+	if err != nil {
+		err = fmt.Errorf("error parsing cluster config, command: Validate, cluster: %s, error: %w", c.Name, err)
+		slog.Error(err.Error())
+		return err
+	}
+
+	if config.Name == "" {
+		err = status.Errorf(codes.FailedPrecondition, "a cluster name must be specified")
+		slog.Error(err.Error())
+		return err
+	}
+
+	if err := followsNamingConvention(config.Name); err != nil {
+		err = fmt.Errorf("cluster name does not follow naming convention: %w", err)
+		slog.Error(err.Error())
+		return err
+	}
+
+	// validate control plane nodes is at least 1
+	if config.Nodes.ControlPlane < 1 {
+		err = status.Errorf(codes.FailedPrecondition, "the number of control plane nodes must be greater than 0")
+		slog.Error(err.Error())
+		return err
+	}
+
+	// validate worker nodes is not negative
+	if config.Nodes.Worker < 0 {
+		err = status.Errorf(codes.FailedPrecondition, "the number of worker nodes cannot be negative")
+		slog.Error(err.Error())
+		return err
+	}
+
+	// validate name, namespace, replicas, and image are specified
+	for _, app := range config.Applications {
+		if app.Name == "" {
+			err = status.Errorf(codes.FailedPrecondition, "application name must not be empty")
+			slog.Error(err.Error())
+			return err
+		}
+
+		if err := followsNamingConvention(app.Name); err != nil {
+			err = fmt.Errorf("application name does not follow naming convention: %w", err)
+			slog.Error(err.Error())
+			return err
+		}
+
+		if app.Namespace == "" {
+			err = status.Errorf(codes.FailedPrecondition, "application namespace must not be empty")
+			slog.Error(err.Error())
+			return err
+		}
+
+		if err := followsNamingConvention(app.Namespace); err != nil {
+			err = fmt.Errorf("application namespace does not follow naming convention: %w", err)
+			slog.Error(err.Error())
+			return err
+		}
+
+		if app.Replicas < 1 {
+			err = status.Errorf(codes.FailedPrecondition, "application replicas must be at least 1")
+			slog.Error(err.Error())
+			return err
+		}
+
+		if app.Image == "" {
+			err = status.Errorf(codes.FailedPrecondition, "application image must not be empty")
+			slog.Error(err.Error())
+			return err
+		}
+
+		if err := imageExists(ctx, app.Image); err != nil {
+			err = fmt.Errorf("error retreiving image %s: %w", app.Image, err)
+			slog.Error(err.Error())
+			return err
+		}
+	}
+
+	slog.Info("Cluster configuration is valid")
+	return nil
+}
+
+func followsNamingConvention(s string) error {
+	// only contains letters, numbers, and hyphens
+	if !regexp.MustCompile(`^[a-z0-9-]*$`).MatchString(s) {
+		return status.Errorf(codes.FailedPrecondition, "only lowercase letters, numbers, and hyphens are allowed")
+	}
+
+	// starts with lowercase letter
+	if firstChar := rune(s[0]); !unicode.IsLower(firstChar) {
+		return status.Errorf(codes.FailedPrecondition, "first char must be a lowercase letter")
+	}
+
+	// does not end with a hyphen
+	if lastChar := rune(s[len(s)-1]); lastChar == '-' {
+		return status.Errorf(codes.FailedPrecondition, "last char must be lowercase letter or number")
+	}
+
+	return nil
+}
+
+func imageExists(ctx context.Context, image string) error {
+	cli, err := client.NewClientWithOpts(client.FromEnv)
+	if err != nil {
+		return fmt.Errorf("error creating docker client: %w", err)
+	}
+
+	_, _, err = cli.ImageInspectWithRaw(ctx, image)
+	if err != nil {
+		return status.Errorf(codes.NotFound, "image does not exist")
+	}
+
+	return nil
+}

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -42,3 +42,19 @@ var DeleteCommand = &cli.Command{
 		return err
 	},
 }
+
+var ValidateCommand = &cli.Command{
+	Name:  "validate",
+	Usage: "validate a cluster configuration",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "file",
+			Usage: "The path to the file where the cluster configuration is stored",
+		},
+	},
+	Action: func(ctx context.Context, cmd *cli.Command) error {
+		cluster := cluster.NewCluster("", cmd.String("file"))
+		err := cluster.Validate(ctx)
+		return err
+	},
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,3 +15,8 @@ Please note that applications have the following fields:
 - `namespace`: The namespace in which the application will reside
 - `replicas`: The number of deployment replicas the application will be deployed on
 - `image`: The application's image
+
+Please note that the names for clusters, application names, and application namespaces must adhere to the following convention:
+- name must only contain lowercase letters, numbers, and hyphens
+- name must start with a lowercase letter
+- name must only end with a lowercase letter or number

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module skillet/skillet-kind
 go 1.22.0
 
 require (
+	github.com/docker/docker v24.0.7+incompatible
 	github.com/urfave/cli/v3 v3.0.0-alpha9
 	google.golang.org/grpc v1.58.3
 	gopkg.in/yaml.v3 v3.0.1
@@ -22,6 +23,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
 	github.com/Masterminds/squirrel v1.5.4 // indirect
+	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/Microsoft/hcsshim v0.11.4 // indirect
 	github.com/alessio/shellescape v1.4.1 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 // indirect
@@ -34,7 +36,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/cli v24.0.6+incompatible // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect
-	github.com/docker/docker v24.0.7+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
@@ -123,13 +124,15 @@ require (
 	go.opentelemetry.io/otel/trace v1.19.0 // indirect
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
 	golang.org/x/crypto v0.17.0 // indirect
+	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/oauth2 v0.10.0 // indirect
-	golang.org/x/sync v0.3.0 // indirect
+	golang.org/x/sync v0.5.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/term v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
+	golang.org/x/tools v0.16.1 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230822172742-b8732ec3820d // indirect
 	google.golang.org/protobuf v1.31.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -436,8 +436,8 @@ golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
-golang.org/x/mod v0.12.0 h1:rmsUpXtvNzj340zd98LZ4KntptpfRHwpFOHG188oHXc=
-golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
+golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -464,8 +464,8 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
-golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
+golang.org/x/sync v0.5.0 h1:60k92dhOjHxJkrqnwsfl8KuaHbn/5dl0lUPUklKo3qE=
+golang.org/x/sync v0.5.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ func main() {
 		Commands: []*cli.Command{
 			cmd.CreateCommand,
 			cmd.DeleteCommand,
+			cmd.ValidateCommand,
 		},
 	}
 


### PR DESCRIPTION
This PR adds a command that validates a cluster configuration file. Additionally, the same logic is applied to the beginning of the cluster creation process.