### PR TITLE
Deploy applications as daemon sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ User applications have the following fields:
 - `namespace`: The namespace in which the application will reside
 - `replicas`: The number of deployment replicas the application will be deployed on
 - `image`: The application's image
+- `type`: The type of resource that the application will be created as. Currently supported resources are DaemonSets (`daemonset`) and Deployments (`deployment`)
 
 Please note that the names for clusters, application names, and application namespaces must adhere to the following convention:
 - name must only contain lowercase letters, numbers, and hyphens

--- a/cluster/application.go
+++ b/cluster/application.go
@@ -16,6 +16,7 @@ type Application struct {
 	Namespace string `yaml:"namespace"`
 	Replicas  int    `yaml:"replicas"`
 	Image     string `yaml:"image"`
+	Type      string `yaml:"type"`
 }
 
 func (c *Cluster) DeployApplications(ctx context.Context, clientset *kubernetes.Clientset) error {
@@ -29,7 +30,16 @@ func (c *Cluster) DeployApplications(ctx context.Context, clientset *kubernetes.
 	// read applications from cluster config
 	for _, app := range clusterConfig.Applications {
 		slog.Info("Deploying application", "application", app.Name)
-		app.CreateDeployment(ctx, clientset)
+		switch app.Type {
+		case "deployment":
+			app.CreateDeployment(ctx, clientset)
+		case "daemonset":
+			app.CreateDaemonset(ctx, clientset)
+		default:
+			err = fmt.Errorf("application type must be one of [deployment, daemonset]")
+			slog.Error(err.Error())
+			return err
+		}
 		slog.Info("Successfully deployed application", "application", app.Name)
 	}
 
@@ -87,6 +97,59 @@ func (a *Application) CreateDeployment(ctx context.Context, clientset *kubernete
 	}
 
 	slog.Info("Successfully created deployment", "application", a.Name)
+	return nil
+}
+
+func (a *Application) CreateDaemonset(ctx context.Context, clientset *kubernetes.Clientset) error {
+	slog.Info("Creating daemonset", "application", a.Name)
+	err := a.CreateNamespace(ctx, clientset)
+	if err != nil {
+		err = fmt.Errorf("error creating namespace for application %s: %w", a.Name, err)
+		slog.Error(err.Error())
+		return err
+	}
+
+	slog.Info("Creating deployment", "application", a.Name)
+
+	daemonsetsClient := clientset.AppsV1().DaemonSets(a.Namespace)
+
+	daemonset := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: a.Name,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": a.Name,
+				},
+			},
+			Template: apiv1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": a.Name,
+					},
+				},
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{
+							Name:  a.Name,
+							Image: a.Image,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// _, err = deploymentsClient.Create(ctx, deployment, metav1.CreateOptions{})
+	_, err = daemonsetsClient.Create(ctx, daemonset, metav1.CreateOptions{})
+	if err != nil {
+		err = fmt.Errorf("error creating daemonset %s: %w", a.Name, err)
+		slog.Error(err.Error())
+		return err
+	}
+
+	slog.Info("Successfully created daemonset", "application", a.Name)
 	return nil
 }
 

--- a/cluster/application.go
+++ b/cluster/application.go
@@ -29,7 +29,7 @@ func (c *Cluster) DeployApplications(ctx context.Context, clientset *kubernetes.
 	// read applications from cluster config
 	for _, app := range clusterConfig.Applications {
 		slog.Info("Deploying application", "application", app.Name)
-		app.ApplyDeployment(ctx, clientset)
+		app.CreateDeployment(ctx, clientset)
 		slog.Info("Successfully deployed application", "application", app.Name)
 	}
 
@@ -37,8 +37,8 @@ func (c *Cluster) DeployApplications(ctx context.Context, clientset *kubernetes.
 	return nil
 }
 
-// deploy an application
-func (a *Application) ApplyDeployment(ctx context.Context, clientset *kubernetes.Clientset) error {
+func (a *Application) CreateDeployment(ctx context.Context, clientset *kubernetes.Clientset) error {
+	slog.Info("Creating deployment", "application", a.Name)
 	err := a.CreateNamespace(ctx, clientset)
 	if err != nil {
 		err = fmt.Errorf("error creating namespace for application %s: %w", a.Name, err)
@@ -46,18 +46,6 @@ func (a *Application) ApplyDeployment(ctx context.Context, clientset *kubernetes
 		return err
 	}
 
-	err = a.CreateDeployment(ctx, clientset)
-	if err != nil {
-		err = fmt.Errorf("error creating deployment for application %s: %w", a.Name, err)
-		slog.Error(err.Error())
-		return err
-	}
-
-	slog.Info("Successfully applied deployment", "application", a.Name)
-	return nil
-}
-
-func (a *Application) CreateDeployment(ctx context.Context, clientset *kubernetes.Clientset) error {
 	slog.Info("Creating deployment", "application", a.Name)
 
 	deploymentsClient := clientset.AppsV1().Deployments(a.Namespace)
@@ -91,7 +79,7 @@ func (a *Application) CreateDeployment(ctx context.Context, clientset *kubernete
 		},
 	}
 
-	_, err := deploymentsClient.Create(ctx, deployment, metav1.CreateOptions{})
+	_, err = deploymentsClient.Create(ctx, deployment, metav1.CreateOptions{})
 	if err != nil {
 		err = fmt.Errorf("error creating deployment %s: %w", a.Name, err)
 		slog.Error(err.Error())

--- a/cluster/validate.go
+++ b/cluster/validate.go
@@ -72,8 +72,21 @@ func (c *Cluster) Validate(ctx context.Context) error {
 			return err
 		}
 
-		if app.Replicas < 1 {
-			err = status.Errorf(codes.FailedPrecondition, "application replicas must be at least 1")
+		switch app.Type {
+		case "daemonset":
+			if app.Replicas > 0 {
+				err = status.Errorf(codes.FailedPrecondition, "replicas cannot be specified for daemonsets")
+				slog.Error(err.Error())
+				return err
+			}
+		case "deployment":
+			if app.Replicas < 1 {
+				err = status.Errorf(codes.FailedPrecondition, "application replicas must be at least 1")
+				slog.Error(err.Error())
+				return err
+			}
+		default:
+			err = status.Errorf(codes.FailedPrecondition, "application type must be one of [deployment, daemonset]")
 			slog.Error(err.Error())
 			return err
 		}

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,6 +15,7 @@ Please note that applications have the following fields:
 - `namespace`: The namespace in which the application will reside
 - `replicas`: The number of deployment replicas the application will be deployed on
 - `image`: The application's image
+- `type`: The type of resource that the application will be created as. Currently supported resources are DaemonSets (`daemonset`) and Deployments (`deployment`)
 
 Please note that the names for clusters, application names, and application namespaces must adhere to the following convention:
 - name must only contain lowercase letters, numbers, and hyphens

--- a/examples/cluster.yaml
+++ b/examples/cluster.yaml
@@ -7,5 +7,10 @@ nodes:
 applications:
 - name: getting-started
   namespace: getting-started-app
-  replicas: 2
   image: hmcnelis/getting-started:latest
+  type: daemonset
+- name: bank-web-app
+  namespace: bank-web-app-ns
+  replicas: 2
+  image: hmcnelis/bank-web-app:2024.02.18.1
+  type: deployment


### PR DESCRIPTION
### Overview

This PR allows a user to deploy their application as a daemon set. The following changes were made:
- Applications can now be deployed as daemon sets
- Validation added to prevent a number of replicas being specified in the `cluster.yaml` for daemon sets
- Refactored function `CreateDeployment` to get rid of function `ApplyDeployment`