### PR TITLE
Use exit codes in main

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,5 +21,10 @@ func main() {
 		},
 	}
 
-	cmd.Run(ctx, os.Args)
+	err := cmd.Run(ctx, os.Args)
+	if err != nil {
+		os.Exit(1)
+	}
+
+	os.Exit(0)
 }


### PR DESCRIPTION
### Overview

This PR updates the `main` function so that it exits with codes 0 or 1.